### PR TITLE
Api v1 search item

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -4,7 +4,12 @@ class Api::V1::ItemsController < ApplicationController
   end 
 
   def show
-    render json: ItemSerializer.new(Item.find(params[:id]))
+    if params[:name].present?
+      item = Item.search(params[:name]).first 
+      render json: ItemSerializer.new(Item.find(item.id))
+    else 
+      render json: ItemSerializer.new(Item.find(params[:id]))
+    end
   end 
 
   def create 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,4 +2,8 @@ class Item < ApplicationRecord
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
   belongs_to :merchant
+
+  def self.search(search_params)
+    where("name ILIKE ?", "%#{search_params}%")
+  end
 end 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper' 
+
+RSpec.describe Item do 
+  it "can return search result of search" do 
+    merchant = create(:merchant)
+    create_list(:item, 3, merchant_id: merchant.id)
+    item = create(:item, name: "laptop", merchant_id: merchant.id)
+    
+    expect(Item.search("laptop").first).to eq(item)
+  end 
+end 

--- a/spec/requests/api/v1/items/search_item_request_spec.rb
+++ b/spec/requests/api/v1/items/search_item_request_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper' 
+
+RSpec.describe "Gets Item Based on Search" do  
+  it "sends an item from a search" do 
+    merchant = create(:merchant)
+    create_list(:item, 3, merchant_id: merchant.id)
+    item = create(:item, name: "Pancakes", merchant_id: merchant.id)
+    search = "Pancake"
+
+    get "/api/v1/items/find?name=#{search}"
+    
+    search_result = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful 
+    expect(search_result.count). to eq(1)
+
+		expect(search_result[:data]).to have_key(:id)
+    
+		expect(search_result[:data][:attributes]).to have_key(:name)
+		expect(search_result[:data][:attributes]).to have_key(:description)
+		expect(search_result[:data][:attributes]).to have_key(:unit_price)
+  end 
+end 


### PR DESCRIPTION
Added: Item class method search to take search criteria and find most similar Item. Method is also tested for in model spec

Test: Endpoint sends an item based on search criteria

Feat: Added if statement to items#show. Will take search criteria and apply it to the Item search method. 
The item.id of the first search result is taken and the response is rendered in json